### PR TITLE
In linux pwnlories should close sockets and continue when exceeds ulimit

### DIFF
--- a/pwnloris.py
+++ b/pwnloris.py
@@ -7,6 +7,7 @@ import time
 import signal
 import threading
 import argparse
+import errno
 
 args = None
 
@@ -49,6 +50,13 @@ def setup_attack(host, port):
                 if args.tor:
                     socks.set_default_proxy(socks.PROXY_TYPE_SOCKS5, args.sockshost, args.socksport)
                     socket.socket = socks.socksocket
+            except OSError as e:
+                # errno.ENOENT (24) is the error number for "Too many open files" when exceeds ulimit
+                if e.errno == errno.ENOENT:
+                    tries_failed += 1
+                    if tries_failed > 5:
+                        break
+                continue
             except:
                 continue
 


### PR DESCRIPTION
Issue: In Linux the pwnloris script stops creating socket when reach to ulimit

Solution: added solution to continue beyond the ulimit,
It will wait till the timeout period and then call the disconnect socket that is already in case of payload failure.
here is the issue link, that I created earlier: https://github.com/h0ussni/pwnloris/issues/2

It is tested on Linux RHEL 8.10 and is working as expected.