### PR TITLE
In linux pwnlories should close sockets and continue when exceeds ulimit

### DIFF
--- a/pwnloris.py
+++ b/pwnloris.py
@@ -7,6 +7,7 @@ import time
 import signal
 import threading
 import argparse
+import errno
 
 args = None
 
@@ -49,6 +50,13 @@ def setup_attack(host, port):
                 if args.tor:
                     socks.set_default_proxy(socks.PROXY_TYPE_SOCKS5, args.sockshost, args.socksport)
                     socket.socket = socks.socksocket
+            except OSError as e:
+                # errno.ENOENT (24) is the error number for "Too many open files" when exceeds ulimit
+                if e.errno == errno.ENOENT:
+                    tries_failed += 1
+                    if tries_failed > 5:
+                        break
+                continue
             except:
                 continue
 


### PR DESCRIPTION
In linux pwnlories should close sockets and continue when exceeds ulimit.

Added exception handling for Linux error number **24** is for **errno.EMFILE**.

tested:
<img width="772" alt="Screenshot 2024-12-03 at 12 00 49 PM" src="https://github.com/user-attachments/assets/8318db8d-3cf8-4f04-b4fa-15b633474418">
